### PR TITLE
feat: implement Phase 1 - basic memo functionality with CRUD API

### DIFF
--- a/nest-cli.json
+++ b/nest-cli.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://json.schemastore.org/nest-cli",
+  "collection": "@nestjs/schematics",
+  "sourceRoot": "src",
+  "compilerOptions": {
+    "deleteOutDir": true
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,69 @@
+{
+  "name": "nest-memo",
+  "version": "0.0.1",
+  "description": "",
+  "author": "",
+  "private": true,
+  "license": "UNLICENSED",
+  "scripts": {
+    "build": "nest build",
+    "format": "prettier --write \"src/**/*.ts\" \"test/**/*.ts\"",
+    "start": "nest start",
+    "start:dev": "nest start --watch",
+    "start:debug": "nest start --debug --watch",
+    "start:prod": "node dist/main",
+    "lint": "eslint \"{src,apps,libs,test}/**/*.ts\" --fix",
+    "test": "jest",
+    "test:watch": "jest --watch",
+    "test:cov": "jest --coverage",
+    "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
+    "test:e2e": "jest --config ./test/jest-e2e.json"
+  },
+  "dependencies": {
+    "@nestjs/common": "^10.0.0",
+    "@nestjs/core": "^10.0.0",
+    "@nestjs/platform-express": "^10.0.0",
+    "reflect-metadata": "^0.1.13",
+    "rxjs": "^7.8.1"
+  },
+  "devDependencies": {
+    "@nestjs/cli": "^10.0.0",
+    "@nestjs/schematics": "^10.0.0",
+    "@nestjs/testing": "^10.0.0",
+    "@types/express": "^4.17.17",
+    "@types/jest": "^29.5.2",
+    "@types/node": "^20.3.1",
+    "@types/supertest": "^6.0.0",
+    "@typescript-eslint/eslint-plugin": "^6.0.0",
+    "@typescript-eslint/parser": "^6.0.0",
+    "eslint": "^8.42.0",
+    "eslint-config-prettier": "^9.0.0",
+    "eslint-plugin-prettier": "^5.0.0",
+    "jest": "^29.5.0",
+    "prettier": "^3.0.0",
+    "source-map-support": "^0.5.21",
+    "supertest": "^6.3.3",
+    "ts-jest": "^29.1.0",
+    "ts-loader": "^9.4.3",
+    "ts-node": "^10.9.1",
+    "tsconfig-paths": "^4.2.1",
+    "typescript": "^5.1.3"
+  },
+  "jest": {
+    "moduleFileExtensions": [
+      "js",
+      "json",
+      "ts"
+    ],
+    "rootDir": "src",
+    "testRegex": ".*\\.spec\\.ts$",
+    "transform": {
+      "^.+\\.(t|j)s$": "ts-jest"
+    },
+    "collectCoverageFrom": [
+      "**/*.(t|j)s"
+    ],
+    "coverageDirectory": "../coverage",
+    "testEnvironment": "node"
+  }
+}

--- a/src/app.controller.ts
+++ b/src/app.controller.ts
@@ -1,0 +1,12 @@
+import { Controller, Get } from '@nestjs/common';
+import { AppService } from './app.service';
+
+@Controller()
+export class AppController {
+  constructor(private readonly appService: AppService) {}
+
+  @Get()
+  getHello(): string {
+    return this.appService.getHello();
+  }
+}

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { AppController } from './app.controller';
+import { AppService } from './app.service';
+import { MemoModule } from './memo/memo.module';
+
+@Module({
+  imports: [MemoModule],
+  controllers: [AppController],
+  providers: [AppService],
+})
+export class AppModule {}

--- a/src/app.service.ts
+++ b/src/app.service.ts
@@ -1,0 +1,8 @@
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class AppService {
+  getHello(): string {
+    return 'Hello World!';
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,0 +1,8 @@
+import { NestFactory } from '@nestjs/core';
+import { AppModule } from './app.module';
+
+async function bootstrap() {
+  const app = await NestFactory.create(AppModule);
+  await app.listen(3000);
+}
+bootstrap();

--- a/src/memo/memo.controller.spec.ts
+++ b/src/memo/memo.controller.spec.ts
@@ -1,0 +1,65 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { MemoController } from './memo.controller';
+import { MemoService } from './memo.service';
+
+describe('MemoController', () => {
+  let controller: MemoController;
+  let service: MemoService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [MemoController],
+      providers: [MemoService],
+    }).compile();
+
+    controller = module.get<MemoController>(MemoController);
+    service = module.get<MemoService>(MemoService);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+
+  describe('create', () => {
+    it('should create a memo', () => {
+      const createMemoDto = { title: 'Test Title', content: 'Test Content' };
+      const result = controller.create(createMemoDto);
+      expect(result.title).toBe('Test Title');
+      expect(result.content).toBe('Test Content');
+    });
+  });
+
+  describe('findAll', () => {
+    it('should return an array of memos', () => {
+      controller.create({ title: 'Memo 1', content: 'Content 1' });
+      controller.create({ title: 'Memo 2', content: 'Content 2' });
+      const result = controller.findAll();
+      expect(result).toHaveLength(2);
+    });
+  });
+
+  describe('findOne', () => {
+    it('should return a memo by id', () => {
+      const createdMemo = controller.create({ title: 'Test Title', content: 'Test Content' });
+      const result = controller.findOne(createdMemo.id);
+      expect(result).toEqual(createdMemo);
+    });
+  });
+
+  describe('update', () => {
+    it('should update a memo', () => {
+      const createdMemo = controller.create({ title: 'Original Title', content: 'Original Content' });
+      const updateMemoDto = { title: 'Updated Title', content: 'Updated Content' };
+      const result = controller.update(createdMemo.id, updateMemoDto);
+      expect(result.title).toBe('Updated Title');
+      expect(result.content).toBe('Updated Content');
+    });
+  });
+
+  describe('remove', () => {
+    it('should remove a memo', () => {
+      const createdMemo = controller.create({ title: 'Test Title', content: 'Test Content' });
+      expect(() => controller.remove(createdMemo.id)).not.toThrow();
+    });
+  });
+});

--- a/src/memo/memo.controller.ts
+++ b/src/memo/memo.controller.ts
@@ -1,0 +1,54 @@
+import { 
+  Controller, 
+  Get, 
+  Post, 
+  Put, 
+  Delete, 
+  Body, 
+  Param, 
+  ParseIntPipe 
+} from '@nestjs/common';
+import { MemoService, Memo } from './memo.service';
+
+export interface CreateMemoDto {
+  title: string;
+  content: string;
+}
+
+export interface UpdateMemoDto {
+  title: string;
+  content: string;
+}
+
+@Controller('memos')
+export class MemoController {
+  constructor(private readonly memoService: MemoService) {}
+
+  @Get()
+  findAll(): Memo[] {
+    return this.memoService.findAll();
+  }
+
+  @Get(':id')
+  findOne(@Param('id', ParseIntPipe) id: number): Memo {
+    return this.memoService.findOne(id);
+  }
+
+  @Post()
+  create(@Body() createMemoDto: CreateMemoDto): Memo {
+    return this.memoService.create(createMemoDto.title, createMemoDto.content);
+  }
+
+  @Put(':id')
+  update(
+    @Param('id', ParseIntPipe) id: number,
+    @Body() updateMemoDto: UpdateMemoDto,
+  ): Memo {
+    return this.memoService.update(id, updateMemoDto.title, updateMemoDto.content);
+  }
+
+  @Delete(':id')
+  remove(@Param('id', ParseIntPipe) id: number): void {
+    return this.memoService.remove(id);
+  }
+}

--- a/src/memo/memo.module.ts
+++ b/src/memo/memo.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { MemoController } from './memo.controller';
+import { MemoService } from './memo.service';
+
+@Module({
+  controllers: [MemoController],
+  providers: [MemoService],
+})
+export class MemoModule {}

--- a/src/memo/memo.service.spec.ts
+++ b/src/memo/memo.service.spec.ts
@@ -1,0 +1,77 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { NotFoundException } from '@nestjs/common';
+import { MemoService } from './memo.service';
+
+describe('MemoService', () => {
+  let service: MemoService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [MemoService],
+    }).compile();
+
+    service = module.get<MemoService>(MemoService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  describe('create', () => {
+    it('should create a memo', () => {
+      const memo = service.create('Test Title', 'Test Content');
+      expect(memo).toHaveProperty('id');
+      expect(memo.title).toBe('Test Title');
+      expect(memo.content).toBe('Test Content');
+      expect(memo.createdAt).toBeInstanceOf(Date);
+      expect(memo.updatedAt).toBeInstanceOf(Date);
+    });
+  });
+
+  describe('findAll', () => {
+    it('should return all memos', () => {
+      service.create('Memo 1', 'Content 1');
+      service.create('Memo 2', 'Content 2');
+      const memos = service.findAll();
+      expect(memos).toHaveLength(2);
+    });
+  });
+
+  describe('findOne', () => {
+    it('should return a memo by id', () => {
+      const createdMemo = service.create('Test Title', 'Test Content');
+      const foundMemo = service.findOne(createdMemo.id);
+      expect(foundMemo).toEqual(createdMemo);
+    });
+
+    it('should throw NotFoundException if memo not found', () => {
+      expect(() => service.findOne(999)).toThrow(NotFoundException);
+    });
+  });
+
+  describe('update', () => {
+    it('should update a memo', () => {
+      const createdMemo = service.create('Original Title', 'Original Content');
+      const updatedMemo = service.update(createdMemo.id, 'Updated Title', 'Updated Content');
+      expect(updatedMemo.title).toBe('Updated Title');
+      expect(updatedMemo.content).toBe('Updated Content');
+      expect(updatedMemo.updatedAt.getTime()).toBeGreaterThan(createdMemo.updatedAt.getTime());
+    });
+
+    it('should throw NotFoundException if memo not found', () => {
+      expect(() => service.update(999, 'Title', 'Content')).toThrow(NotFoundException);
+    });
+  });
+
+  describe('remove', () => {
+    it('should remove a memo', () => {
+      const createdMemo = service.create('Test Title', 'Test Content');
+      service.remove(createdMemo.id);
+      expect(() => service.findOne(createdMemo.id)).toThrow(NotFoundException);
+    });
+
+    it('should throw NotFoundException if memo not found', () => {
+      expect(() => service.remove(999)).toThrow(NotFoundException);
+    });
+  });
+});

--- a/src/memo/memo.service.ts
+++ b/src/memo/memo.service.ts
@@ -1,0 +1,56 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+
+export interface Memo {
+  id: number;
+  title: string;
+  content: string;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+@Injectable()
+export class MemoService {
+  private memos: Memo[] = [];
+  private nextId = 1;
+
+  findAll(): Memo[] {
+    return this.memos;
+  }
+
+  findOne(id: number): Memo {
+    const memo = this.memos.find(memo => memo.id === id);
+    if (!memo) {
+      throw new NotFoundException(`Memo with ID ${id} not found`);
+    }
+    return memo;
+  }
+
+  create(title: string, content: string): Memo {
+    const now = new Date();
+    const memo: Memo = {
+      id: this.nextId++,
+      title,
+      content,
+      createdAt: now,
+      updatedAt: now,
+    };
+    this.memos.push(memo);
+    return memo;
+  }
+
+  update(id: number, title: string, content: string): Memo {
+    const memo = this.findOne(id);
+    memo.title = title;
+    memo.content = content;
+    memo.updatedAt = new Date();
+    return memo;
+  }
+
+  remove(id: number): void {
+    const memoIndex = this.memos.findIndex(memo => memo.id === id);
+    if (memoIndex === -1) {
+      throw new NotFoundException(`Memo with ID ${id} not found`);
+    }
+    this.memos.splice(memoIndex, 1);
+  }
+}

--- a/test/app.e2e-spec.ts
+++ b/test/app.e2e-spec.ts
@@ -1,0 +1,24 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { INestApplication } from '@nestjs/common';
+import * as request from 'supertest';
+import { AppModule } from './../src/app.module';
+
+describe('AppController (e2e)', () => {
+  let app: INestApplication;
+
+  beforeEach(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+
+    app = moduleFixture.createNestApplication();
+    await app.init();
+  });
+
+  it('/ (GET)', () => {
+    return request(app.getHttpServer())
+      .get('/')
+      .expect(200)
+      .expect('Hello World!');
+  });
+});

--- a/test/jest-e2e.json
+++ b/test/jest-e2e.json
@@ -1,0 +1,9 @@
+{
+  "moduleFileExtensions": ["js", "json", "ts"],
+  "rootDir": ".",
+  "testEnvironment": "node",
+  "testRegex": ".e2e-spec.ts$",
+  "transform": {
+    "^.+\\.(t|j)s$": "ts-jest"
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "declaration": true,
+    "removeComments": true,
+    "emitDecoratorMetadata": true,
+    "experimentalDecorators": true,
+    "allowSyntheticDefaultImports": true,
+    "target": "ES2021",
+    "sourceMap": true,
+    "outDir": "./dist",
+    "baseUrl": "./",
+    "incremental": true,
+    "skipLibCheck": true,
+    "strictNullChecks": false,
+    "noImplicitAny": false,
+    "strictBindCallApply": false,
+    "forceConsistentCasingInFileNames": false,
+    "noFallthroughCasesInSwitch": false
+  }
+}


### PR DESCRIPTION
Implements Phase 1 of the NestJS memo app as requested in issue #12.

## Changes
- Initialize NestJS project structure with TypeScript configuration
- Create memo module, service, and controller
- Implement in-memory CRUD operations for memos
- Add comprehensive unit tests for memo service and controller
- Set up E2E test configuration

## API Endpoints
- GET /memos - retrieve all memos
- GET /memos/:id - retrieve specific memo
- POST /memos - create new memo
- PUT /memos/:id - update existing memo
- DELETE /memos/:id - delete memo

Fixes #12

Generated with [Claude Code](https://claude.ai/code)